### PR TITLE
Update .gitignore

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -76,3 +76,7 @@ fabric.properties
 
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
+
+# SECURITY
+*.bak
+


### PR DESCRIPTION
Security Fix

Found a .bak file in one of a .php file,
this shouldn't be done in a production environment due to source code exposure
see (Here)[owasp.org/index.php/Review_Old,Backup_and_Unreferenced_Files_for_Sensitive_Information(OTG-CONFIG-004)]
or owasp.org/index.php/Insecure_Configuration_Management

Also feel free to join the worcestershire chapter if you want to learn about security
owasp.org/index.php/Worcestershire
or samuel.aldis@owasp.org

your local owasp is: owasp.org/index.php/Japan